### PR TITLE
Bugfix/FAS-74 no data handling

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,8 +1,8 @@
 class MockResponse:
     """Fake response object."""
 
-    def __init__(self, status=200, body=None, json=None):
-        self.status = status
+    def __init__(self, status_code=200, body=None, json=None):
+        self.status_code = status_code
         self._body = body
         self._json = json
 

--- a/tests/test_metadata/test_ena_client.py
+++ b/tests/test_metadata/test_ena_client.py
@@ -18,7 +18,9 @@ def test_get_srr_ids_from_srp(mocker):
     accession = "SRP163674"
 
     ena_client = ENAClient()
-    mock = mocker.patch.object(requests, "get", return_value=MockResponse(json=accession_response))
+    mock = mocker.patch.object(
+        requests, "get", return_value=MockResponse(json=accession_response, status_code=200)
+    )
     srr_ids = ena_client.get_srr_ids_from_srp(accession)
 
     get_args = mock.call_args_list[0][1]
@@ -180,7 +182,7 @@ def test_backoff_on_get(mocker):
     """Tests if ENAClient._get() retries on RequestError."""
 
     mock = mocker.patch.object(
-        requests, "get", side_effect=[RequestException("whatever"), MockResponse(status=200)]
+        requests, "get", side_effect=[RequestException("whatever"), MockResponse(status_code=200)]
     )  # first time raises an error, second time executes successfully
 
     ena_client = ENAClient(attempts=2)


### PR DESCRIPTION
Handle cases when we request an accession from `ENA API` that it doesn't know

In this PR I created two similar private methods, both names `_get_data()` for `ENAAsyncClient` and `ENAClient`, that wrap around get requests to the ENA API. These methods are for handling exceptions during request and also for handling cases when ENA API doesn't return data for the accession.

Now all the `ENAAsyncClient` and `ENAClient` methods that are requesting some json from ENA API will do it via these `_get_data()` methods.